### PR TITLE
Enable keeping of old published docs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  github-pages:
+  public-current-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -54,3 +54,5 @@ jobs:
         with:
           token: ${{ secrets.JEKYLL_PAT }}
           target_branch: "gh-pages"
+          target_path: /
+          keep_history: true


### PR DESCRIPTION
Enabled an option that should keep the old versions of the docs, so publishing does not always reset the `gh-pages` branch to only have a single commit (which then makes it impossible to tag the old version).